### PR TITLE
Add callbackSuccessRedirectUrl option

### DIFF
--- a/controllers/github.go
+++ b/controllers/github.go
@@ -2,11 +2,18 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+
 	"digger.dev/cloud/middleware"
 	"digger.dev/cloud/models"
 	"digger.dev/cloud/utils"
-	"encoding/json"
-	"fmt"
 	dg_configuration "github.com/diggerhq/digger/libs/digger_config"
 	orchestrator "github.com/diggerhq/digger/libs/orchestrator"
 	dg_github "github.com/diggerhq/digger/libs/orchestrator/github"
@@ -15,12 +22,6 @@ import (
 	"github.com/google/go-github/v55/github"
 	"github.com/google/uuid"
 	"golang.org/x/oauth2"
-	"log"
-	"net/http"
-	"os"
-	"reflect"
-	"strconv"
-	"strings"
 )
 
 func GithubAppWebHook(c *gin.Context) {
@@ -605,7 +606,9 @@ func GithubAppCallbackPage(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error updating GitHub installation"})
 		return
 	}
-	c.Redirect(http.StatusFound, "/repos")
+	//TODO move to config; same for all other os.Getenv() calls in this file
+	callbackSuccessRedirectURL := os.Getenv("CALLBACK_SUCCESS_REDIRECT_URL")
+	c.Redirect(http.StatusFound, callbackSuccessRedirectURL)
 }
 
 func GithubReposPage(c *gin.Context) {


### PR DESCRIPTION
Set `CALLBACK_SUCCESS_REDIRECT_URL` env var to the following:
- production: `https://login.digger.dev?appSuccess=true`
- staging: `https://login.uselemon.cloud?appSuccess=true`

The `appSuccess` param will then be used on the frontend to show success message for app connection